### PR TITLE
Avoid terminal cursor interference

### DIFF
--- a/src/tmv.c
+++ b/src/tmv.c
@@ -611,6 +611,7 @@ void playVideo(const VideoInfo INFO, const int SOUND)
 	int currentFrame = 1;
 	int prevFrame = 0;
 
+	printf("\033[?25l"); //Hide cursor (avoids that one white pixel when playing video)
 	while(1)
 	{
 		char file[1000];
@@ -640,6 +641,7 @@ void playVideo(const VideoInfo INFO, const int SOUND)
 		prevFrame = currentFrame;
 	}
 	freeImage(&prevImage);
+	printf("\033[?25h"); //show cursor again
 }
 
 VideoInfo getVideoInfo(const char TARGET[])


### PR DESCRIPTION
When playing a video the cursor is visible and kinda sticks out